### PR TITLE
Use flat vec as memory arena and fixed size array for hash

### DIFF
--- a/merkle-tree-lib/benches/tagged_hash.rs
+++ b/merkle-tree-lib/benches/tagged_hash.rs
@@ -8,15 +8,19 @@ fn bench_tagged_hash(c: &mut Criterion) {
     let mut group = c.benchmark_group("merkle_tree_lib::tagged_hash");
 
     for max_range in [1, 10, 100, 1_000, 10_000, 100_000, 1_000_000].iter() {
-        group.bench_with_input(BenchmarkId::from_parameter(max_range), max_range, |b, &max_range| {
-            b.iter(|| {
-                std::hint::black_box({
-                    for _ in 0..max_range {
-                        merkle_tree_lib::tagged_hash(&tag_leaf, "aaa".as_bytes());
-                    }
+        group.bench_with_input(
+            BenchmarkId::from_parameter(max_range),
+            max_range,
+            |b, &max_range| {
+                b.iter(|| {
+                    std::hint::black_box({
+                        for _ in 0..max_range {
+                            merkle_tree_lib::tagged_hash(&tag_leaf, "aaa".as_bytes());
+                        }
+                    });
                 });
-            });
-        });
+            },
+        );
     }
 
     group.finish();


### PR DESCRIPTION
Optimization with these changes:

* Use flat vec for the payload of the MerkleTree nodes for reduced heap memory allocations
* Use fixed size array (equivalent of `[u8; 32]`, but defined as `sha2::digest::Output<Sha256>`) for reduced heap memory allocations

## Note

I wanted to make something simple like `type Hash = [u8; Sha256::Size]`, but it's insanely complicated to get the size of the output array size of the hash at compile time. `Sha256` is a typedef of `CoreWrapper<CtVariableCoreWrapper<Sha256VarCore, U32, OidSha256>>`, and `sha2::digest::Output<Sha256>` resolves to `GenericArray<u8, UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>>`, but there is no easy way to extract this "32" from the type. The best thing I could do is `std::mem::size_of::<Hash>()`. The sha2 crate type system is way too overengineered if you ask me, but that's what we've got.
